### PR TITLE
gemini: Set MIUI 7.7.6 dev firmware as minimal requirement

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,1 +1,1 @@
-require version-modem=2017-04-11 00:05:12
+require version-modem=2017-07-05 22:52:07


### PR DESCRIPTION
 * If using an older firmware, headphones won't work

Change-Id: Ic7ae737f4ee4ac515c3c028bd389a77175444556