### PR TITLE
gemini: Use handset-stereo-dmic-ef for camcorder-mic usecase

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -50,7 +50,7 @@
         <device name="SND_DEVICE_IN_BT_SCO_MIC_NREC" acdb_id="835"/>
         <device name="SND_DEVICE_IN_BT_SCO_MIC_WB" acdb_id="1347"/>
         <device name="SND_DEVICE_IN_BT_SCO_MIC_WB_NREC" acdb_id="1859"/>
-        <device name="SND_DEVICE_IN_CAMCORDER_MIC" acdb_id="4"/>
+        <device name="SND_DEVICE_IN_CAMCORDER_MIC" acdb_id="2069"/>
         <device name="SND_DEVICE_IN_VOICE_DMIC" acdb_id="277"/>
         <device name="SND_DEVICE_IN_VOICE_SPEAKER_DMIC" acdb_id="293"/>
         <device name="SND_DEVICE_IN_VOICE_REC_MIC" acdb_id="4"/>
@@ -85,6 +85,9 @@
         <device name="SND_DEVICE_OUT_VOICE_TTY_FULL_HEADPHONES" backend="headphones" interface="SLIMBUS_6_RX"/>
         <device name="SND_DEVICE_OUT_VOICE_TTY_VCO_HEADPHONES" backend="headphones" interface="SLIMBUS_6_RX"/>
     </backend_names>
+    <device_names>
+        <device name="SND_DEVICE_IN_CAMCORDER_MIC" alias="handset-stereo-dmic-ef"/>
+    </device_names>
     <pcm_ids>
         <usecase name="USECASE_AUDIO_RECORD_LOW_LATENCY" type="in" id="19" />
         <usecase name="USECASE_AUDIO_PLAYBACK_ULL" type="out" id="19" />


### PR DESCRIPTION
* Some apps seem to be using this and that results
  in better audio volume and quality. The example
  app that uses handset-stereo-dmic-ef is: Footej.

Change-Id: I70e5e9461c4108dd0bb22603a5b45c2a4add13be