### PR TITLE
gemini: Force usage of stock HiFi headphones ACDB ID

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -28,8 +28,8 @@
     <acdb_ids>
         <device name="SND_DEVICE_OUT_HANDSET" acdb_id="18"/>
         <device name="SND_DEVICE_OUT_SPEAKER" acdb_id="34"/>
-        <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="52"/>
-        <device name="SND_DEVICE_OUT_HEADPHONES_44_1" acdb_id="52"/>
+        <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="564"/>
+        <device name="SND_DEVICE_OUT_HEADPHONES_44_1" acdb_id="564"/>
         <device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" acdb_id="34"/>
         <device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="18"/>
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER" acdb_id="34"/>


### PR DESCRIPTION
 * Apparently this DSP path is not affected by the shitty Dirac sound effect.

 * There is no support for such sound effect and was somehow enabled by default
   (called "Mi Sound" in MIUI) on the regular path, causing an uneven frequency
   response while listening to music through headphones.

BUGBASH-247

Change-Id: I3b59f7a19f5ef38213f4a6ae39f6fbaf5569992b