### PR TITLE
gemini: nfc: Advertise extended length support for IsoDep frames

### DIFF
--- a/nfc/libnfc-brcm.conf
+++ b/nfc/libnfc-brcm.conf
@@ -398,3 +398,7 @@ NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:70:FF:FF}
 # Bail out mode
 #  If set to 1, NFCC is using bail out mode for either Type A or Type B poll.
 NFA_POLL_BAIL_OUT_MODE=0x01
+
+###############################################################################
+# Max transceive length for ISO_DEP
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF


### PR DESCRIPTION
 * Stock uses NXP HALs thus we need to set this to 0xFEFF to match it

Change-Id: I759f9d8db6e1d1b130d3be8fb8e570db25f9020b